### PR TITLE
Fix makefile.

### DIFF
--- a/makefile
+++ b/makefile
@@ -14,7 +14,6 @@ TESTS=SimpleTest.hs \
 
 SOURCES=$(TESTS) \
 			Lexer.hs \
-			SimpleParse.hs \
 			CheckedMonad.hs \
 			ErrorChecking.hs \
 			Examples.hs \
@@ -29,8 +28,7 @@ SOURCES=$(TESTS) \
 			StatefulMonad.hs \
 			Simple.hs \
 			Substitute.hs \
-			TopLevelFunctions.hs \
-			Base.hs
+			TopLevelFunctions.hs
 
 verb: anatomyVerbatim.pdf
 	open anatomyVerbatim.pdf


### PR DESCRIPTION
`make code` was unable to build due to multiple issues.
- create / remove directories `code` and `output` for appropriate targets
- removed missing files from `$(SOURCES)`
- make whitespacing consistent

A remaining issue is the lack of `Base` module that most of the Haskell code depends on.
