### PR TITLE
Remove TODO about point-free style.

### DIFF
--- a/anatomy.lhs
+++ b/anatomy.lhs
@@ -1990,8 +1990,6 @@ The comprehensions used earlier in this document could be replace by invocations
 
 |[evaluate a env BAR a <- args]|   \ \ \ \  $\equiv$  \ \ \ \  |map (\a-> evaluate a env) args| %Mapp12
 
-TODO: make a comment about point-free style? %Mapp13
-
 TODO: is a function that returns a function also called higher order? %Mapp14
 
  ### Representing Environments as Functions {#EnvAsFun}


### PR DESCRIPTION
While I personally like point-free style when appropriate, I feel that it's unnecessary and a distraction at this point in the book for a few reasons.

First of all, (AFAIK) this is a Haskell implementation detail and the book is about the programming languages as a whole. Second, it is not possible to explain point-free style without first explaining currying, which is a section unto itself.
