### PR TITLE
Remove commented bindF and don't include in output source.

### DIFF
--- a/anatomy.lhs
+++ b/anatomy.lhs
@@ -2070,8 +2070,7 @@ write a *higher-order* function. A higher-order function is one that
 takes a function as input or returns a function as an result. The
 function |bindF| takes an |EnvF| as an input and returns a new |EnvF|. %Repr14
 
-INCLUDE:Repr15
-> -- bindF :: String -> Value -> EnvF -> EnvF
+> bindF :: String -> Value -> EnvF -> EnvF
 > -- %Repr15
 
 Expanding the definition of |EnvF| makes the higher-order nature of |bindF| clear: %Repr16

--- a/src/FunctionalEnvironment.hs
+++ b/src/FunctionalEnvironment.hs
@@ -8,9 +8,6 @@ emptyEnvF = \var -> Nothing
 --END:Repr31
 
 bindF :: String -> a -> (String -> Maybe a) -> (String -> Maybe a)
---BEGIN:Repr15
--- bindF :: String -> Value -> EnvF -> EnvF
---END:Repr15
 
 --BEGIN:Repr19
 bindF var val env = \testVar -> if testVar == var


### PR DESCRIPTION
The first `bindF` is commented out to prevent collision with a later re-declaration. However this causes the arrows to not be rendered correctly.

![screenshot from 2014-02-04 09 43 30](https://f.cloud.github.com/assets/622170/2077594/bab2dc6c-8db3-11e3-82f1-c9fe82f03e30.png)

This is the original generated `code/FunctionalEnvironment.hs`:

``` haskell
bindF :: String -> a -> (String -> Maybe a) -> (String -> Maybe a)
-- bindF :: String -> Value -> EnvF -> EnvF

bindF var val env = \testVar -> if testVar == var
                                then Just val
                                else env testVar
```

And after this change:

``` haskell
bindF :: String -> a -> (String -> Maybe a) -> (String -> Maybe a)

bindF var val env = \testVar -> if testVar == var
                                then Just val
                                else env testVar
```
